### PR TITLE
Add support for returning token probabilities in CTC decoder

### DIFF
--- a/asr_decoder/prefix_score.py
+++ b/asr_decoder/prefix_score.py
@@ -38,6 +38,7 @@ class PrefixScore:
         self.context_state = context_state
         self.context_score = context_score
         self.has_context = False
+        self.token_probs = []  # The maximum probability of each token
 
     def score(self):
         return log_add(self.s, self.ns)


### PR DESCRIPTION
Return the probability for each token, taking the maximum probability for consecutive identical tokens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an option to receive token probability scores along with decoding outputs, allowing for enhanced insight into recognition confidence.
  - Improved tracking of token confidence during decoding to support more detailed analysis of transcription performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->